### PR TITLE
Remove -o flag from check for existing wg0.conf

### DIFF
--- a/wireguard-autoconfig.sh
+++ b/wireguard-autoconfig.sh
@@ -33,7 +33,7 @@ while [[ $hasQR == '' ]];do
 done
 
 hasConf=$(ls /etc/wireguard)
-while [[ $(echo $hasConf | grep -o 'wg0.conf') == 'wg0.conf' ]];do
+while [[ $(echo $hasConf | grep 'wg0.conf') == 'wg0.conf' ]];do
     echo 'wg0.conf already exists, exiting.'
     exit 0
     break;


### PR DESCRIPTION
grep -o only prints matching chars, results in old/backed up configs in directory being treated as active configs. There’s probably a better way to check for configs that have established services associated with them, but as a quick-and-dirty fix, I’ve just removed the -o flag from that check to fix #9 